### PR TITLE
Error if no timepoint is provided for longitudinal data

### DIFF
--- a/R/mtxDE.R
+++ b/R/mtxDE.R
@@ -47,11 +47,14 @@ run_single_beta_reg_zibr <- function(logistic_cov=NULL, beta_cov, Y,
     }
     # If no timepoint column, assume each sample is from the same timepoint
     if(is.null(time_ind)){
+        # If there are multiple timepoints for any participant
+        if(length(unique(subject_ind_dat)) != length(subject_ind_dat)){
+            stop("A timepoint column is necessary if there are longitudinal samples.")
+        }
         time_ind_dat <- as.matrix(rep(1, nrow(data)))
     } else {
         time_ind_dat <- as.matrix(data[,time_ind])
     }
-
 
     mod <- ZIBR::zibr(
                logistic_cov=logistic_cov_dat,
@@ -155,6 +158,7 @@ run_mtxDE <- function(formula, feature.table, metadata, sampleID,
     # merge the feature table and metadata based on the rownames
     formula <- paste0(" ~ ", formula)
     metadata.vars <- c(all.vars(as.formula(formula)), sampleID)
+
     data <- merge(feature.table,
                   metadata[,c(metadata.vars, zibr_time_ind)],
                   by.x="row.names", by.y=sampleID)

--- a/tests/testthat/test-mtxDE.R
+++ b/tests/testthat/test-mtxDE.R
@@ -118,3 +118,27 @@ test_that("run_mtxDE works", {
                  colnames(expected.gamlss))
 
 })
+
+test_that("ZIBR timepoint errors", {
+    feature.table <- data.frame(a=c(0.1, 0.0, 0.0, 0.0),
+                                b=c(0.5, 0.5, 0.5, 0.4),
+                                c=c(0.4, 0.5, 0.0, 0.0),
+                                d=c(0.0, 0.0, 0.5, 0.6))
+    row.names(feature.table) <- paste0("sample_", 1:4)
+    metadata <- data.frame(SampleID=paste0("sample_", 1:4),
+                           phenotype=c(0,0,1,1),
+                           participant=c(0,1,0,1),
+                           unique_participants=1:4,
+                           timepoint=c(0,0,1,1))
+    # Longitudinal but no timepoint column
+    expect_error(run_mtxDE("phenotype + (1|participant)",
+                           feature.table,
+                           metadata, sampleID="SampleID",
+                           zibr_time_ind=NULL),
+                 "A timepoint column is necessary if there are longitudinal samples.")
+    # Not longitudinal with no timepoint column
+    expect_no_error(run_mtxDE("phenotype + (1|unique_participants)",
+                           feature.table,
+                           metadata, sampleID="SampleID",
+                           zibr_time_ind=NULL))
+})


### PR DESCRIPTION
Previously, if no timepoint was passed to `ZIBR` for `run_mtxDE`, it would create constant time. If a user specifies participant-level random effects for longitudinal data but doesn't provide a timepoint var, `ZIBR` would raise a confusing (ambiguous-sounding) error. This raises an error before it gets to `ZIBR`.