### PR TITLE
Update readme to include vignette arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Statistics tools for host-microbiome dual transcriptomics
 To install HoMiStats with the latest updates from GitHub:
 
 ```
+devtools::install_github("sterrettJD/HoMiStats")
+```
+
+To install HoMiStats with vignettes: 
+```
 devtools::install_github("sterrettJD/HoMiStats", build_vignettes = TRUE)
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Statistics tools for host-microbiome dual transcriptomics
 To install HoMiStats with the latest updates from GitHub:
 
 ```
-devtools::install_github("sterrettJD/HoMiStats")
+devtools::install_github("sterrettJD/HoMiStats", build_vignettes = TRUE)
 ```
 
 


### PR DESCRIPTION
This adds the `build_vignettes` option to the github readme. 